### PR TITLE
변이 종류 추가 (PHI)

### DIFF
--- a/src/utils.ml
+++ b/src/utils.ml
@@ -16,7 +16,7 @@ module OpcodeClass = struct
   let mem_list = [ Llvm.Opcode.Alloca; Load; Store ]
   let cast_list = [ Llvm.Opcode.Trunc; ZExt; SExt; PtrToInt; IntToPtr; BitCast ]
   let cmp_list = [ Llvm.Opcode.ICmp ]
-  let phi_list = [] (* PHI *)
+  let phi_list = [ Llvm.Opcode.PHI ] (* PHI *)
   let other_list = []
 
   let total_list =
@@ -30,7 +30,7 @@ module OpcodeClass = struct
     | Alloca | Load | Store -> MEM
     | Trunc | ZExt | SExt | PtrToInt | IntToPtr | BitCast -> CAST
     | ICmp -> CMP
-    | _ when false -> PHI
+    | PHI -> PHI
     | FAdd | FSub | FMul | FDiv | FRem | FPToUI | FPToSI | UIToFP | SIToFP
     | FPTrunc | FPExt | FCmp ->
         raise Out_of_integer_domain
@@ -107,6 +107,7 @@ module OpcodeClass = struct
     | _ -> raise Unsupported
 
   let build_cmp icmp = Llvm.build_icmp icmp
+  let build_phi = Llvm.build_phi
 end
 
 (** [get_list_index l v] returns the index of value [v] in list [l].


### PR DESCRIPTION
기존 명령과 더불어 PHI 명령이 변이를 통해 무작위로 추가됩니다. ([이곳](https://github.com/prosyslab/llfuzz/compare/master...Timber-min:llfuzz:master#diff-f897a0d82012602abb504bdd7f3ec2fe7a9349bffc80cbe8eb104ba7d3d119f1R295-R316)과 [이곳](https://github.com/prosyslab/llfuzz/compare/master...Timber-min:llfuzz:master#diff-f897a0d82012602abb504bdd7f3ec2fe7a9349bffc80cbe8eb104ba7d3d119f1R71-R83))

PHI 노드의 추가에 따라 기존 함수 일부가 수정되었습니다. (예를 들어, 블록을 쪼개는 함수는 기존 블록의 모든 사용을 대체했었습니다. 이젠 종결자(terminator)만 바꿉니다.)