### PR TITLE
코드 유지보수

### DIFF
--- a/src/config.ml
+++ b/src/config.ml
@@ -1,13 +1,21 @@
 let project_home = ref ""
-let out_dir = ref "llfuzz-out"
+
+(* directories *)
 let seed_dir = ref "seed"
-let alive2_bin = ref "alive2/build/alive-tv"
+let out_dir = ref "llfuzz-out"
+let crash_dir = ref "llfuzz-crash"
+
+(* binary files and flags *)
 let bin = ref "llvm-project/build/bin/opt"
+let alive2_bin = ref "alive2/build/alive-tv"
 let no_tv = ref false
+
+(* fuzzing options *)
 let mutate_times = ref 5
 let fuzzing_times = ref 5
 let alive2_log = ref "alive-tv.txt"
-let crash_log = ref "crashes.txt"
+
+(* logging options *)
 let log_time = ref 30.0
 
 (* whitelist
@@ -17,14 +25,15 @@ let _instCombine = ref true
 let opts =
   [
     ("-out-dir", Arg.Set_string out_dir, "Output directory");
+    ( "-crash-dir",
+      Arg.Set_string crash_dir,
+      "Output directory for crashing mutants" );
     ("-no-tv", Arg.Set no_tv, "Turn off translation validation");
     ("-mut-time", Arg.Set_int mutate_times, "Change mutation times");
     ("-fuz-time", Arg.Set_int fuzzing_times, "Change fuzzing times");
-    ("-crash-log", Arg.Set_string crash_log, "Output of crashed mutations");
     ( "-log-time",
       Arg.Set_float log_time,
       "Change time interval for creating logs" );
-    (* whitelist *)
     ( "-instcombine",
       Arg.Set _instCombine,
       "[register whitelist] Combine instructions to form fewer, simple \

--- a/src/utils.ml
+++ b/src/utils.ml
@@ -161,9 +161,3 @@ let choose_function llm =
   match Llvm.function_begin llm with
   | Before f -> f
   | At_end _ -> failwith "No function defined"
-
-(** [note_module_list l file] print all modules in list[l] to [file]. *)
-let note_module_list l file =
-  let fp = open_out file in
-  List.iter (fun i -> i |> Llvm.string_of_llmodule |> output_string fp) l;
-  close_out fp


### PR DESCRIPTION
- 기존: 크래시(crash)를 일으키는 변이(mutant) 모두를 **파일 하나에 연달아** 출력했습니다.
  - 변경: 크래시를 일으키는 변이 각각을 **같은 디렉토리 아래 개별 파일**로 출력합니다.
- 기존: 크래시를 일으키는 변이를 리스트로 모아 **마지막에 한 번에 출력**했습니다.
  - 변경: 크래시를 일으키는 변이를 **감지 즉시 출력**합니다.
- 추가적으로 수정해야 하는 부분을 발견하여, `TODO`와 `FIXME` 태그로 표시하였습니다.
- 기존 코드에서 `-no-tv` 옵션을 주었을 때 발생하는 오류를 해결하였습니다.
- Config와 겹치는 마법 리터럴(magic literal)이 config를 참조하도록 변경하였습니다.
- 불필요한 코드를 삭제하고, 값 이름을 바꾸고, 주석을 추가하였습니다.
- (작은 변경) 이제 퍼징 시간을 출력합니다.