### PR TITLE
[Mutator] retry if fail

### DIFF
--- a/src/util/LUtil.ml
+++ b/src/util/LUtil.ml
@@ -207,3 +207,11 @@ let choose_function llm =
 let replace_hard bef aft =
   Llvm.replace_all_uses_with bef aft;
   Llvm.delete_instruction bef
+
+let replace_and_ret instr_old instr_new =
+  replace_hard instr_old instr_new;
+  Some instr_new
+
+let set_opd_and_ret instr i opd =
+  Llvm.set_operand instr i opd;
+  Some instr


### PR DESCRIPTION
**문제**
일부 변형 함수가 시드를 변형하지 않은 채 그대로 반환하였습니다.
변형이 불가능한 경우를 처리하고자 고안된 방법이었으나,
한 시드에서 발생하는 자식 시드의 개수를 줄이는 효과가 발생했습니다.

**분석**
- 여전히 변형이 불가능한 경우를 처리해야 합니다.
- 변형 전과 후가 다른지를 효과적으로 확인할 수 있어야 합니다.
- 해당 방식으로의 변형이 불가능하다면, 그대로 반환하지 않고 다른 방식의 변형을 시도하여야 합니다.

**대응**
기존 함수들의 반환형을 `option`으로 감싸고, [이곳](https://github.com/prosyslab/llfuzz/compare/master...p-has-done:llfuzz:master#diff-7a7dce77683a7329f70d86ed63d43d3a5d20e9ce0f0a81f1d75b3344f942b8d6R383-R385)에서 값에 따라 선택적으로 재귀합니다.