### PR TITLE
변이를 추적할 수 있도록 corpus에 저장되는 시드의 파일명 변경

### DIFF
--- a/src/fuzz/fuzzer.ml
+++ b/src/fuzz/fuzzer.ml
@@ -56,17 +56,6 @@ let record_timestamp cov =
     F.sprintf "%d %d\n" (now - !AUtil.start_time) (CD.Coverage.cardinal cov)
     |> output_string AUtil.timestamp_fp)
 
-let name_seed ?(parent : SeedPool.seed_t option) (seed : SeedPool.seed_t) =
-  let hash = ALlvm.string_of_llmodule seed.llm |> Hashtbl.hash in
-  match parent with
-  | None ->
-      Format.sprintf "id:%010d,score:%f,covers:%b.ll" hash seed.score
-        seed.covers
-  | Some { llm = src; _ } ->
-      Format.sprintf "id:%010d,src:%010d,score:%f,covers:%b.ll" hash
-        (ALlvm.string_of_llmodule src |> Hashtbl.hash)
-        seed.score seed.covers
-
 let check_mutant filename mutant target_path (seed : SeedPool.seed_t) progress =
   let score_func =
     match !Config.metric with
@@ -97,7 +86,7 @@ let check_mutant filename mutant target_path (seed : SeedPool.seed_t) progress =
       L.debug "mutant score: %f, covers: %b\n" new_seed.score new_seed.covers;
       if new_seed.covers || ((not seed.covers) && new_seed.score < seed.score)
       then (
-        let corpus_name = name_seed ~parent:seed new_seed in
+        let corpus_name = SeedPool.name_seed ~parent:seed new_seed in
         ALlvm.save_ll !Config.corpus_dir corpus_name mutant;
         let progress =
           progress |> Progress.inc_gen |> Progress.add_cov cov_mutant

--- a/src/main.ml
+++ b/src/main.ml
@@ -72,6 +72,12 @@ let main () =
   F.printf "#initial seeds: %d@." (SeedPool.cardinal seed_pool);
   L.info "initial seeds: %d" (SeedPool.cardinal seed_pool);
 
+  seed_pool
+  |> SeedPool.iter (fun seed ->
+         let filename = SeedPool.name_seed seed in
+         F.eprintf "%s@." filename;
+         ALlvm.save_ll !Config.corpus_dir filename seed.llm);
+
   if SeedPool.cardinal seed_pool = 0 then (
     F.printf "no seed loaded@.";
     exit 0);

--- a/src/seedcorpus/seedpool.ml
+++ b/src/seedcorpus/seedpool.ml
@@ -14,6 +14,17 @@ type t = seed_t AUtil.PrioQueue.queue
 let pp_seed fmt seed =
   Format.fprintf fmt "score: %.3f, covers: %b" seed.score seed.covers
 
+let name_seed ?(parent : seed_t option) (seed : seed_t) =
+  let hash = ALlvm.string_of_llmodule seed.llm |> Hashtbl.hash in
+  match parent with
+  | None ->
+      Format.sprintf "id:%010d,score:%f,covers:%b.ll" hash seed.score
+        seed.covers
+  | Some { llm = src; _ } ->
+      Format.sprintf "id:%010d,src:%010d,score:%f,covers:%b.ll" hash
+        (ALlvm.string_of_llmodule src |> Hashtbl.hash)
+        seed.score seed.covers
+
 let get_prio covers score =
   if covers then 0 else score |> Float.mul 10.0 |> Float.to_int
 

--- a/src/seedcorpus/seedpool.mli
+++ b/src/seedcorpus/seedpool.mli
@@ -11,6 +11,7 @@ type seed_t = {
 type t = seed_t AUtil.PrioQueue.queue
 
 val pp_seed : Format.formatter -> seed_t -> unit
+val name_seed : ?parent:seed_t -> seed_t -> string
 val make : ALlvm.llcontext -> unit ALlvm.LLModuleSet.t -> t
 val get_prio : bool -> float -> int
 val pop : t -> seed_t * t


### PR DESCRIPTION
## 목적

1. 재현이 오래 걸리는 경우 변이된 llmodule이 어떤 llmodule에서 변이되었는지 추적해보는 과정이 필요함
2. 변이가 일어난 것을 모두 로그로 기록해 추적하면 비효율적임. AFL의 방법을 사용해 조상 llmodule을 추적할 수 있도록 파일이름 변경.

## 구현

새로운 파일이름 형식 `id:xxxxxxxxxxxx,src:yyyyyyyyyy,score:1.1111111,covers:true.ll`

`src`를 보고 조상을 추적할 수 있음.



---

#78  에 의존적