### PR TITLE
[Misc] use Random.self_init

### DIFF
--- a/src/main.ml
+++ b/src/main.ml
@@ -9,7 +9,7 @@ let llctx = ALlvm.create_context ()
 
 let initialize () =
   Config.initialize llctx ();
-  Random.init !Config.random_seed
+  Random.self_init ()
 
 let do_pattern_only llset () =
   let name, pat = !Config.pattern_path |> Pattern.Parser.run in


### PR DESCRIPTION
Use `Random.self_init ()` instead of `Random.init ...` to ensure that our fuzzer generates relevant test cases regardless of random seed initialization.