### PR TITLE
Vector opcodes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,4 @@ compile_flags.txt
 cov
 pattern-check
 clean
+alive-tv

--- a/src/config.ml
+++ b/src/config.ml
@@ -76,6 +76,7 @@ module Interests = struct
     interesting_integer_types :=
       [
         integer_type llctx 1;
+        integer_type llctx 4;
         integer_type llctx 8;
         integer_type llctx 10;
         integer_type llctx 32;
@@ -95,6 +96,7 @@ module Interests = struct
       ];
     interesting_types := !interesting_integer_types @ !interesting_vector_types
 end
+
 
 (* logging options *)
 let log_time = ref 30
@@ -230,10 +232,13 @@ let initialize llctx () =
   (* make directories first *)
   (try Sys.mkdir !out_dir 0o755
    with Sys_error msg ->
-     F.eprintf "%s@." msg;
-     F.eprintf "It seems like the output directory already exists.@.";
-     F.eprintf "We don't want to mess up with existing files. Exiting...@.";
-     exit 0);
+     (* Check if corpus and crash directory are there already *)
+     if Sys.file_exists !corpus_dir && Sys.file_exists !crash_dir then (
+       F.eprintf "%s@." msg;
+       F.eprintf "It seems like the output directory already exists.@.";
+       F.eprintf "We don't want to mess up with existing files. Exiting...@.";
+       exit 0)
+     else ());
   (try Sys.mkdir !crash_dir 0o755 with _ -> ());
   (try Sys.mkdir !corpus_dir 0o755 with _ -> ());
 
@@ -260,12 +265,11 @@ let initialize llctx () =
 
   Interests.set_interesting_types llctx;
 
-  if !dry_run then (
+  if !dry_run then
     opts
     |> List.iter (fun (name, spec, _) ->
            match spec with
            | Arg.Set b -> Format.printf "%s: %b\n" name !b
            | Arg.Set_string s -> Format.printf "%s: %s\n" name !s
            | Arg.Set_int i -> Format.printf "%s: %d\n" name !i
-           | _ -> failwith "not implemented");
-    exit 0)
+           | _ -> failwith "not implemented")

--- a/src/program/check_corpus.ml
+++ b/src/program/check_corpus.ml
@@ -37,6 +37,7 @@ let check_transformation llfile =
 let args = ref []
 let ntasks = ref 12
 let re = ref None
+let tv_bin = ref "./alive-tv"
 
 let speclist =
   [
@@ -44,6 +45,7 @@ let speclist =
     ( "-re",
       Arg.String (fun s -> re := Some (Str.regexp s)),
       "regular expression to filter files" );
+    ("-tv-bin", Arg.String (fun s -> tv_bin := s), "alive-tv binary");
   ]
 
 let bar ~total =
@@ -75,6 +77,8 @@ let _ =
    with Sys_error _ ->
      Sys.command "rm -rf tmp" |> ignore;
      Sys.mkdir "tmp" 0o777);
+
+  Config.alive_tv_bin := !tv_bin;
 
   let out_dir = !args |> List.hd in
   let corpus_dir = Filename.concat out_dir "corpus" in

--- a/src/program/clean.ml
+++ b/src/program/clean.ml
@@ -4,7 +4,7 @@ open Util
 let main input_file =
   let llctx = ALlvm.create_context () in
   Format.printf "input file: %s@." input_file;
-  let llm = ALlvm.read_ll llctx input_file in
+  let llm = ALlvm.read_ll llctx input_file |> Result.get_ok in
   Format.printf "input module: %s@." (ALlvm.string_of_llmodule llm);
   match Prep.clean_llm llctx true llm with
   | None ->

--- a/src/seedcorpus/prep.ml
+++ b/src/seedcorpus/prep.ml
@@ -24,7 +24,8 @@ let rec redef_fn llctx f_old wide instr =
 
         (* copy function with new return value (target).*)
         ALlvm.ChangeRetVal.copy_blocks llctx f_old f_new;
-        ALlvm.ChangeRetVal.migrate llctx f_old f_new i;
+        (try ALlvm.ChangeRetVal.migrate llctx f_old f_new i
+         with _ -> ALlvm.delete_function f_new);
 
         true)
       else redef_fn llctx f_old wide i

--- a/src/util/aLlvm.ml
+++ b/src/util/aLlvm.ml
@@ -245,8 +245,10 @@ let is_llvm_intrinsic instr =
   else false
 
 let read_ll llctx filepath =
-  let buf = Llvm.MemoryBuffer.of_file filepath in
-  Llvm_irreader.parse_ir llctx buf
+  try
+    let buf = Llvm.MemoryBuffer.of_file filepath in
+    Llvm_irreader.parse_ir llctx buf |> Result.ok
+  with Llvm_irreader.Error msg -> Result.Error msg
 
 (** [save_ll target_dir output filename llmodule] saves [llmodule]
  *  under [target_dir], named as [filename].

--- a/test/mutator/ch-type/test.ml
+++ b/test/mutator/ch-type/test.ml
@@ -2,7 +2,7 @@ open Util
 
 let main () =
   let llctx = ALlvm.create_context () in
-  let llm = ALlvm.read_ll llctx Sys.argv.(1) in
+  let llm = ALlvm.read_ll llctx Sys.argv.(1) |> Result.get_ok in
 
   Config.Interests.set_interesting_types llctx;
 

--- a/test/mutator/create-instr/test.ml
+++ b/test/mutator/create-instr/test.ml
@@ -2,7 +2,7 @@ open Util
 
 let main () =
   let llctx = ALlvm.create_context () in
-  let llm = ALlvm.read_ll llctx Sys.argv.(1) in
+  let llm = ALlvm.read_ll llctx Sys.argv.(1) |> Result.get_ok in
 
   Logger.from_file "debug.log";
   Logger.set_level Logger.DEBUG;

--- a/test/mutator/cut/test.ml
+++ b/test/mutator/cut/test.ml
@@ -2,7 +2,7 @@ open Util
 
 let main () =
   let llctx = ALlvm.create_context () in
-  let llm = ALlvm.read_ll llctx Sys.argv.(1) in
+  let llm = ALlvm.read_ll llctx Sys.argv.(1) |> Result.get_ok in
 
   Logger.from_file "debug.log";
   Logger.set_level Logger.DEBUG;


### PR DESCRIPTION
- InsertElement, ExtractElement, ShuffleVector 명령 추가.
- 관련하여 CREATE와 TYPE 구현.
- 그 과정에서 CREATE가 피연산자를 선정하는 방식을 약간 수정.
- #120

resolves #116 